### PR TITLE
Fix Quill initialization for post content submission

### DIFF
--- a/resources/views/admin/posts/create.blade.php
+++ b/resources/views/admin/posts/create.blade.php
@@ -161,11 +161,11 @@
 </style>
 @endpush
 
+
 @push('scripts')
 <script src="https://cdn.quilljs.com/1.3.6/quill.js"></script>
 <script>
-document.addEventListener('DOMContentLoaded', function () {
-    const quill = new Quill('#editor', {
+const quill = new Quill('#editor', {
         theme: 'snow',
         placeholder: 'Comece a escrever seu post...',
         modules: {
@@ -180,22 +180,21 @@ document.addEventListener('DOMContentLoaded', function () {
         }
     });
 
-    // Restaura conteúdo após validação falhar
-    @if(old('content'))
-        quill.root.innerHTML = @json(old('content'));
-    @endif
+// Restaura conteúdo após validação falhar
+@if(old('content'))
+    quill.root.innerHTML = @json(old('content'));
+@endif
 
-    // Copia o HTML do Quill para o campo hidden antes de enviar
-    const form = document.querySelector('form');
-    form.addEventListener('submit', function (e) {
-        const content = quill.root.innerHTML;
-        if (content.trim() === '<p><br></p>' || content.trim() === '') {
-            e.preventDefault();
-            alert('Por favor, adicione conteúdo ao post.');
-            return false;
-        }
-        document.getElementById('content').value = content;
-    });
+// Copia o HTML do Quill para o campo hidden antes de enviar
+const form = document.querySelector('form');
+form.addEventListener('submit', function (e) {
+    const content = quill.root.innerHTML;
+    if (content.trim() === '<p><br></p>' || content.trim() === '') {
+        e.preventDefault();
+        alert('Por favor, adicione conteúdo ao post.');
+        return false;
+    }
+    document.getElementById('content').value = content;
 });
 </script>
 @endpush

--- a/resources/views/admin/posts/edit.blade.php
+++ b/resources/views/admin/posts/edit.blade.php
@@ -184,11 +184,11 @@
 </style>
 @endpush
 
+
 @push('scripts')
 <script src="https://cdn.quilljs.com/1.3.6/quill.js"></script>
 <script>
-document.addEventListener('DOMContentLoaded', function () {
-    const quill = new Quill('#editor', {
+const quill = new Quill('#editor', {
         theme: 'snow',
         placeholder: 'Comece a escrever seu post...',
         modules: {
@@ -203,23 +203,22 @@ document.addEventListener('DOMContentLoaded', function () {
         }
     });
 
-    // Carrega o conteúdo existente do post
-    const existingContent = @json(old('content', $post->content));
-    if (existingContent) {
-        quill.root.innerHTML = existingContent;
-    }
+// Carrega o conteúdo existente do post
+const existingContent = @json(old('content', $post->content));
+if (existingContent) {
+    quill.root.innerHTML = existingContent;
+}
 
-    // Copia o HTML do Quill para o campo hidden antes de enviar
-    const form = document.querySelector('form');
-    form.addEventListener('submit', function (e) {
-        const content = quill.root.innerHTML;
-        if (content.trim() === '<p><br></p>' || content.trim() === '') {
-            e.preventDefault();
-            alert('Por favor, adicione conteúdo ao post.');
-            return false;
-        }
-        document.getElementById('content').value = content;
-    });
+// Copia o HTML do Quill para o campo hidden antes de enviar
+const form = document.querySelector('form');
+form.addEventListener('submit', function (e) {
+    const content = quill.root.innerHTML;
+    if (content.trim() === '<p><br></p>' || content.trim() === '') {
+        e.preventDefault();
+        alert('Por favor, adicione conteúdo ao post.');
+        return false;
+    }
+    document.getElementById('content').value = content;
 });
 </script>
 @endpush


### PR DESCRIPTION
## Summary
- Initialize Quill editor immediately on create/edit post forms
- Ensure editor HTML is copied to hidden `content` field before submitting

## Testing
- `php artisan test` *(fails: SQLSTATE[HY000] [2002] Connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_6898d1b7a7d08325a3a922fab164bcde