### PR TITLE
Atualiza sincronização do Quill com campo oculto

### DIFF
--- a/resources/views/admin/posts/create.blade.php
+++ b/resources/views/admin/posts/create.blade.php
@@ -175,26 +175,30 @@ const quill = new Quill('#editor', {
                 [{ 'list': 'ordered'}, { 'list': 'bullet' }],
                 [{ 'align': [] }],
                 ['link', 'image'],
-                ['clean']
+                ['clean'],
             ]
         }
-    });
+    }),
+    contentInput = document.getElementById('content');
 
 // Restaura conteúdo após validação falhar
 @if(old('content'))
     quill.root.innerHTML = @json(old('content'));
+    contentInput.value = @json(old('content'));
 @endif
 
-// Copia o HTML do Quill para o campo hidden antes de enviar
+// Atualiza o campo hidden sempre que o texto mudar
+quill.on('text-change', function () {
+    contentInput.value = quill.root.innerHTML;
+});
+
+// Valida antes de enviar
 const form = document.querySelector('form');
 form.addEventListener('submit', function (e) {
-    const content = quill.root.innerHTML;
-    if (content.trim() === '<p><br></p>' || content.trim() === '') {
+    if (quill.getText().trim().length === 0) {
         e.preventDefault();
         alert('Por favor, adicione conteúdo ao post.');
-        return false;
     }
-    document.getElementById('content').value = content;
 });
 </script>
 @endpush

--- a/resources/views/admin/posts/edit.blade.php
+++ b/resources/views/admin/posts/edit.blade.php
@@ -201,24 +201,28 @@ const quill = new Quill('#editor', {
                 ['clean']
             ]
         }
-    });
+    }),
+    contentInput = document.getElementById('content');
 
 // Carrega o conteúdo existente do post
 const existingContent = @json(old('content', $post->content));
 if (existingContent) {
     quill.root.innerHTML = existingContent;
+    contentInput.value = existingContent;
 }
 
-// Copia o HTML do Quill para o campo hidden antes de enviar
+// Atualiza o campo hidden sempre que o texto mudar
+quill.on('text-change', function () {
+    contentInput.value = quill.root.innerHTML;
+});
+
+// Valida antes de enviar
 const form = document.querySelector('form');
 form.addEventListener('submit', function (e) {
-    const content = quill.root.innerHTML;
-    if (content.trim() === '<p><br></p>' || content.trim() === '') {
+    if (quill.getText().trim().length === 0) {
         e.preventDefault();
         alert('Por favor, adicione conteúdo ao post.');
-        return false;
     }
-    document.getElementById('content').value = content;
 });
 </script>
 @endpush


### PR DESCRIPTION
## Summary
- Preenche automaticamente o campo oculto `content` via evento `text-change` do Quill
- Garante validação antes do envio do formulário para evitar posts sem conteúdo

## Testing
- `php artisan test` *(1 failing)*

------
https://chatgpt.com/codex/tasks/task_e_6898d6cc17c08325b5319eb4354784ae