### PR TITLE
Refactor blog views with minimal card layout

### DIFF
--- a/resources/views/blog/category.blade.php
+++ b/resources/views/blog/category.blade.php
@@ -5,42 +5,38 @@
 
 @section('content')
 <div class="mb-8">
-    <!-- Voltar ao blog -->
     <div class="mb-6">
-        <a href="{{ route('blog.index') }}" class="post-link">← Voltar ao blog</a>
+        <a href="{{ route('blog.index') }}" class="text-sm text-gray-500 hover:text-gray-900">← Voltar ao blog</a>
     </div>
-    
-    <!-- Título da categoria -->
+
     <h1 class="text-3xl font-bold text-gray-900 mb-4">{{ $category->name }}</h1>
-    
+
     @if($category->description)
         <p class="text-gray-600 mb-4">{{ $category->description }}</p>
     @endif
-    
+
     <p class="text-gray-500 text-sm mb-6">{{ $posts->total() }} post(s) nesta categoria</p>
 </div>
 
-<!-- Lista de posts -->
-<div class="month-section">
-    <ul class="post-list">
-        @forelse($posts as $post)
-            <li class="post-item">
-                <a href="{{ route('blog.show', $post) }}" class="post-link">
-                    {{ $post->title }}
-                </a>
-                <span class="text-gray-500 text-sm ml-2">
-                    • {{ $post->published_at->format('d/m/Y') }}
-                </span>
-            </li>
-        @empty
-            <li class="text-center py-12">
-                <p class="text-gray-600">Nenhum post encontrado nesta categoria</p>
-            </li>
-        @endforelse
-    </ul>
-</div>
+@if($posts->isEmpty())
+    <div class="p-12 text-center">
+        <svg class="mx-auto h-12 w-12 text-gray-300" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
+        </svg>
+        <h3 class="mt-4 text-lg font-medium text-gray-900">Nenhum post encontrado</h3>
+        <p class="mt-2 text-sm text-gray-600">Nenhum post encontrado nesta categoria</p>
+    </div>
+@else
+    <div class="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
+        @foreach($posts as $post)
+            <a href="{{ route('blog.show', $post) }}" class="block p-6 bg-white border border-gray-100 rounded-lg hover:shadow-sm transition">
+                <h2 class="text-lg font-medium text-gray-900">{{ $post->title }}</h2>
+                <p class="mt-4 text-xs text-gray-500 text-right">{{ $post->published_at->format('d/m/Y') }}</p>
+            </a>
+        @endforeach
+    </div>
+@endif
 
-<!-- Paginação -->
 @if($posts->hasPages())
     <div class="mt-8">
         {{ $posts->links() }}
@@ -49,14 +45,12 @@
 @endsection
 
 @section('sidebar')
-<div class="sidebar">
-    <h3 class="sidebar-title">Navegação</h3>
-    
-    <a href="{{ route('blog.index') }}" class="sidebar-link">← Voltar ao blog</a>
-    
-    <div class="mt-6 pt-4 border-t border-gray-200">
-        <h4 class="sidebar-title text-sm">Sobre esta categoria</h4>
-        <div class="text-sm text-gray-600">
+<div class="space-y-2">
+    <a href="{{ route('blog.index') }}" class="block text-gray-600 hover:text-gray-900 text-sm">← Voltar ao blog</a>
+
+    <div class="pt-4 border-t border-gray-200">
+        <h4 class="text-sm font-medium text-gray-900">Sobre esta categoria</h4>
+        <div class="mt-2 text-sm text-gray-600">
             <p class="mb-2"><strong>Nome:</strong> {{ $category->name }}</p>
             @if($category->description)
                 <p class="mb-2"><strong>Descrição:</strong> {{ $category->description }}</p>
@@ -64,12 +58,12 @@
             <p><strong>Posts:</strong> {{ $posts->total() }}</p>
         </div>
     </div>
-    
+
     @auth
-        <div class="mt-6 pt-4 border-t border-gray-200">
-            <h4 class="sidebar-title text-sm">Admin</h4>
-            <a href="{{ route('admin.categories.edit', $category) }}" class="sidebar-link">Editar categoria</a>
-            <a href="{{ route('admin.categories.index') }}" class="sidebar-link">Todas as categorias</a>
+        <div class="pt-4 border-t border-gray-200">
+            <h4 class="text-sm font-medium text-gray-900">Admin</h4>
+            <a href="{{ route('admin.categories.edit', $category) }}" class="block text-gray-600 hover:text-gray-900 text-sm">Editar categoria</a>
+            <a href="{{ route('admin.categories.index') }}" class="block text-gray-600 hover:text-gray-900 text-sm">Todas as categorias</a>
         </div>
     @endauth
 </div>

--- a/resources/views/blog/index.blade.php
+++ b/resources/views/blog/index.blade.php
@@ -5,49 +5,41 @@
 @section('description', 'Últimos posts do nosso blog')
 
 @section('content')
-@forelse($groupedPosts as $group)
-    <div class="month-section" id="{{ strtolower($group['anchor']) }}">
-        <h2 class="month-title">
-            {{ $group['year'] }} - {{ $group['month'] }}
-            @if(request()->has('month'))
-                <span class="text-gray-400 text-lg font-normal">#</span>
-            @endif
-        </h2>
-        
-        <ul class="post-list">
-            @foreach($group['posts'] as $post)
-                <li class="post-item">
-                    <a href="{{ route('blog.show', $post) }}" class="post-link">
-                        {{ $post->title }}
-                    </a>
-                </li>
+    <div class="mb-8">
+        <h1 class="text-2xl font-semibold text-gray-900">Posts</h1>
+        <p class="mt-1 text-sm text-gray-600">Últimos posts publicados</p>
+    </div>
+
+    @php
+        $posts = $groupedPosts->flatMap(fn($group) => $group['posts']);
+    @endphp
+
+    @if($posts->isEmpty())
+        <div class="p-12 text-center">
+            <svg class="mx-auto h-12 w-12 text-gray-300" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
+            </svg>
+            <h3 class="mt-4 text-lg font-medium text-gray-900">Nenhum post encontrado</h3>
+            <p class="mt-2 text-sm text-gray-600">Seja o primeiro a publicar um post!</p>
+        </div>
+    @else
+        <div class="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
+            @foreach($posts as $post)
+                <a href="{{ route('blog.show', $post) }}" class="block p-6 bg-white border border-gray-100 rounded-lg hover:shadow-sm transition">
+                    <h2 class="text-lg font-medium text-gray-900">{{ $post->title }}</h2>
+                    <p class="mt-4 text-xs text-gray-500 text-right">{{ $post->published_at->format('d/m/Y') }}</p>
+                </a>
             @endforeach
-        </ul>
-    </div>
-@empty
-    <div class="text-center py-12">
-        <h2 class="text-xl text-gray-600">Nenhum post encontrado</h2>
-        <p class="text-gray-500 mt-2">Seja o primeiro a publicar um post!</p>
-    </div>
-@endforelse
+        </div>
+    @endif
 @endsection
 
 @section('sidebar')
-<div class="sidebar">
-    <h3 class="sidebar-title">On this page</h3>
-    
-    @foreach($sidebarDates as $date)
-        <a href="#{{ $date['anchor'] }}" class="sidebar-link">
-            {{ $date['label'] }}
-        </a>
-    @endforeach
-    
     @auth
-        <div class="mt-6 pt-4 border-t border-gray-200">
-            <h4 class="sidebar-title text-sm">Admin</h4>
-            <a href="{{ route('admin.posts.index') }}" class="sidebar-link">Gerenciar Posts</a>
-            <a href="{{ route('admin.categories.index') }}" class="sidebar-link">Gerenciar Categorias</a>
+        <div class="space-y-2">
+            <h3 class="text-sm font-medium text-gray-900">Admin</h3>
+            <a href="{{ route('admin.posts.index') }}" class="block text-gray-600 hover:text-gray-900 text-sm">Gerenciar Posts</a>
+            <a href="{{ route('admin.categories.index') }}" class="block text-gray-600 hover:text-gray-900 text-sm">Gerenciar Categorias</a>
         </div>
     @endauth
-</div>
 @endsection

--- a/resources/views/blog/show.blade.php
+++ b/resources/views/blog/show.blade.php
@@ -7,80 +7,72 @@
 @section('content')
 <div class="max-w-none">
     <article class="mb-8">
-        <!-- Voltar ao blog -->
         <div class="mb-6">
-            <a href="{{ route('blog.index') }}" class="post-link">← Voltar ao blog</a>
+            <a href="{{ route('blog.index') }}" class="text-sm text-gray-500 hover:text-gray-900">← Voltar ao blog</a>
         </div>
-        
-        <!-- Título do post -->
+
         <h1 class="text-3xl font-bold text-gray-900 mb-4">{{ $post->title }}</h1>
-        
-        <!-- Meta informações -->
+
         <div class="mb-6 text-gray-600 text-sm">
             <span>{{ $post->published_at->format('d/m/Y') }}</span>
             @if($post->category)
                 <span class="mx-2">•</span>
-                <a href="{{ route('blog.category', $post->category) }}" class="post-link">
+                <a href="{{ route('blog.category', $post->category) }}" class="text-gray-500 hover:text-gray-900">
                     {{ $post->category->name }}
                 </a>
             @endif
             <span class="mx-2">•</span>
             <span>Por {{ $post->user->name }}</span>
         </div>
-        
-        <!-- Conteúdo -->
+
         <div class="prose max-w-none">
             {!! nl2br(e($post->content)) !!}
         </div>
     </article>
 
-    <!-- Posts relacionados -->
     @if($relatedPosts->count() > 0)
         <div class="mt-12 pt-6 border-t border-gray-200">
             <h3 class="text-lg font-semibold text-gray-900 mb-4">Posts Relacionados</h3>
-            <ul class="post-list">
+            <div class="space-y-3">
                 @foreach($relatedPosts as $relatedPost)
-                    <li class="post-item">
-                        <a href="{{ route('blog.show', $relatedPost) }}" class="post-link">
-                            {{ $relatedPost->title }}
-                        </a>
-                    </li>
+                    <a href="{{ route('blog.show', $relatedPost) }}" class="block text-gray-600 hover:text-gray-900">
+                        {{ $relatedPost->title }}
+                    </a>
                 @endforeach
-            </ul>
+            </div>
         </div>
     @endif
-
 </div>
 @endsection
 
 @section('sidebar')
-<div class="sidebar">
-    <h3 class="sidebar-title">Navegação</h3>
-    
-    <a href="{{ route('blog.index') }}" class="sidebar-link">← Voltar ao blog</a>
-    
+<div class="space-y-2">
+    <a href="{{ route('blog.index') }}" class="block text-gray-600 hover:text-gray-900 text-sm">← Voltar ao blog</a>
+
     @if($post->category)
-        <a href="{{ route('blog.category', $post->category) }}" class="sidebar-link">
+        <a href="{{ route('blog.category', $post->category) }}" class="block text-gray-600 hover:text-gray-900 text-sm">
             Mais posts em {{ $post->category->name }}
         </a>
     @endif
-    
+
     @if($relatedPosts->count() > 0)
-        <div class="mt-4">
-            <h4 class="sidebar-title text-sm">Posts Relacionados</h4>
-            @foreach($relatedPosts->take(5) as $relatedPost)
-                <a href="{{ route('blog.show', $relatedPost) }}" class="sidebar-link">
-                    {{ Str::limit($relatedPost->title, 40) }}
-                </a>
-            @endforeach
+        <div class="pt-4 border-t border-gray-200">
+            <h4 class="text-sm font-medium text-gray-900">Posts Relacionados</h4>
+            <div class="mt-2 space-y-1">
+                @foreach($relatedPosts->take(5) as $relatedPost)
+                    <a href="{{ route('blog.show', $relatedPost) }}" class="block text-gray-600 hover:text-gray-900 text-sm">
+                        {{ Str::limit($relatedPost->title, 40) }}
+                    </a>
+                @endforeach
+            </div>
         </div>
     @endif
-    
+
     @auth
-        <div class="mt-6 pt-4 border-t border-gray-200">
-            <h4 class="sidebar-title text-sm">Admin</h4>
-            <a href="{{ route('admin.posts.edit', $post) }}" class="sidebar-link">Editar este post</a>
-            <a href="{{ route('admin.posts.index') }}" class="sidebar-link">Todos os posts</a>
+        <div class="pt-4 border-t border-gray-200">
+            <h4 class="text-sm font-medium text-gray-900">Admin</h4>
+            <a href="{{ route('admin.posts.edit', $post) }}" class="block text-gray-600 hover:text-gray-900 text-sm">Editar este post</a>
+            <a href="{{ route('admin.posts.index') }}" class="block text-gray-600 hover:text-gray-900 text-sm">Todos os posts</a>
         </div>
     @endauth
 </div>


### PR DESCRIPTION
## Summary
- Redesign blog index with card-based post listing and admin quick links
- Update category page to use cards for posts and clearer sidebar info
- Refresh post detail page styling and related posts section

## Testing
- `php artisan test` *(fails: SQLSTATE[HY000] [2002] Connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_6898db9b224c8325b11e121dc52b515d